### PR TITLE
Remove need for _static directory in docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,6 +55,5 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
 
 version = __version__


### PR DESCRIPTION
Remove need for _static dir

## Changes

- Remove html_static_path from docs configuration

## API Updates

### New Features *(required)*
none

### Deprecations *(required)*

none

### Enhancements *(optional)*

Docs should now pass.

## Checklist

- [x] Unit tests
- [x] Documentation
