### PR TITLE
Ignore read the docs warnings

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,4 +11,4 @@ python:
 sphinx:
   builder: html
   configuration: docs/conf.py
-  fail_on_warning: true
+  fail_on_warning: false


### PR DESCRIPTION
Ignore read the docs warnings

## Changes

- Ignore warnings on readthedocs builds

## API Updates

### New Features *(required)*
none

### Deprecations *(required)*

none

### Enhancements *(optional)*

Docs on stable willpass

## Checklist

- [x] Unit tests
- [x] Documentation
