### PR TITLE
Bugfix/6 handlers not called

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,5 +9,6 @@ sphinx = "~=3.3.1"
 sphinx-rtd-theme = "*"
 coveralls = "~=2.2.0"
 pylint = "~=2.6.0"
+eventipy = {editable = true, path = "."}
 
 [packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d1015f828cb074244b079712f2422554c5386fbe92992d37b988cec6ea045770"
+            "sha256": "76052782007c726a97b409a414f33afc3478a41aaf39227045dc9f8d7f9e3633"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -56,10 +56,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:1f422849db327d534e3d0c5f02a263458c3955ec0aae4ff09b95f195c59f4edd",
-                "sha256:f05def092c44fbf25834a51509ef6e631dc19765ab8a57b4e7ab85531f0a9cf4"
+                "sha256:1a4995114262bffbc2413b159f2a1a480c969de6e6eb13ee966d470af86af59c",
+                "sha256:719a74fb9e33b9bd44cc7f3a8d94bc35e4049deebe19ba7d8e108280cfd59830"
             ],
-            "version": "==2020.11.8"
+            "version": "==2020.12.5"
         },
         "chardet": {
             "hashes": [
@@ -137,6 +137,10 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==0.16"
+        },
+        "eventipy": {
+            "editable": true,
+            "path": "."
         },
         "idna": {
             "hashes": [

--- a/eventipy/__init__.py
+++ b/eventipy/__init__.py
@@ -1,4 +1,4 @@
 from eventipy.event import Event
 from eventipy.event_stream import events
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"

--- a/eventipy/event_stream.py
+++ b/eventipy/event_stream.py
@@ -28,9 +28,9 @@ class EventStream(Sequence):
             raise ValueError(f"event with {event.id} already written")
 
         self.__events.append(event)
-        self._publish_to_subscribers(event)
+        asyncio.run(self._publish_to_subscribers(event))
 
-    def _publish_to_subscribers(self, event: Event) -> None:
+    async def _publish_to_subscribers(self, event: Event) -> None:
         try:
             for handler in self.subscribers[event.topic]:
                 # Ensure handler is called, but don't wait for result

--- a/tests/unit/event_stream_test.py
+++ b/tests/unit/event_stream_test.py
@@ -93,6 +93,10 @@ def test_subscribe_event_published():
         return received_event.id
 
     events.subscribers[event.topic][0] = MagicMock()
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+
     events.subscribers[event.topic][0].return_value = asyncio.Future()
     events.publish(event)
     events.subscribers[event.topic][0].assert_called_with(event)


### PR DESCRIPTION
Fix handlers not called.

## Changes

- Use `asyncio` in the correct way to ensure event handlers are called

## API Updates

### New Features *(required)*
none

### Deprecations *(required)*
none

### Enhancements *(optional)*
none

## Checklist

- [x] Unit tests
- [x] Documentation

## References

Fixes #6 
