### PR TITLE
Add ability to subscribe without using a decorator

### DIFF
--- a/docs/subscribing.rst
+++ b/docs/subscribing.rst
@@ -13,3 +13,17 @@ In order to subscribe to events:
         print(event.id)
 
 every time that an event with topic ``my-topic`` is published, ``event_handler`` will be called.
+
+You can also subscribe without using a decorator like this:
+
+.. code-block:: python
+
+    from eventipy import events, Event
+
+    def event_handler(event: Event):
+        # Do something with event
+        print(event.id)
+
+    events.subscribe("my-topic", event_handler)
+
+This is useful if you don't want to subscribe right away.

--- a/eventipy/__init__.py
+++ b/eventipy/__init__.py
@@ -1,4 +1,4 @@
 from eventipy.event import Event
 from eventipy.event_stream import events
 
-__version__ = "1.0.1"
+__version__ = "1.1.0"

--- a/eventipy/event_handler.py
+++ b/eventipy/event_handler.py
@@ -1,0 +1,5 @@
+from typing import Callable, Any
+
+from eventipy import Event
+
+EventHandler = Callable[[Event], Any]

--- a/eventipy/event_stream.py
+++ b/eventipy/event_stream.py
@@ -6,6 +6,7 @@ from typing import List, Callable, Dict
 from uuid import UUID
 
 from eventipy.event import Event
+from eventipy.event_handler import EventHandler
 
 logger = logging.getLogger(__name__)
 
@@ -38,13 +39,14 @@ class EventStream(Sequence):
         except KeyError:
             pass
 
-    def subscribe(self, topic: str) -> Callable:
+    def subscribe(self, topic: str, event_handler: EventHandler = None) -> Callable:
         """
         Args:
             topic (str): The topic to which this handler listens
+            event_handler (Callable[[Event], None]): Optional handler to give to avoid using decorator
         """
 
-        def wrapper(event_handler: Callable[..., None]) -> Callable:
+        def wrapper(event_handler: EventHandler) -> Callable:
             @wraps(event_handler)
             async def handle_event(event: Event):
                 try:
@@ -56,6 +58,9 @@ class EventStream(Sequence):
 
             self._add_subscriber(topic, handler=handle_event)
             return event_handler
+
+        if event_handler:
+            return wrapper(event_handler)
 
         return wrapper
 


### PR DESCRIPTION
Add ability to subscribe without using a decorator

## Changes

- Add ability to subscribe without using decorator 

## API Updates

### New Features *(required)*

* Add parameter `event_handler` to `events.subscribe` which allows subscribing directly.

### Deprecations *(required)*

none

## Checklist

- [x] Unit tests
- [x] Documentation

## References

Adds functionality requested in #9
