### PR TITLE
Feature/subscribe to all

### DIFF
--- a/docs/subscribing.rst
+++ b/docs/subscribing.rst
@@ -27,3 +27,45 @@ You can also subscribe without using a decorator like this:
     events.subscribe("my-topic", event_handler)
 
 This is useful if you don't want to subscribe right away.
+
+
+Subscribing to all topics
+-------------------------
+
+In order to subscribe to all topics:
+
+.. code-block:: python
+
+    from eventipy import events, Event
+
+    @events.subscribe_to_all
+    def event_handler(event: Event):
+        # Do something with event
+        print(event.id)
+
+Without decorator:
+
+.. code-block:: python
+
+    from eventipy import events, Event
+
+    def event_handler(event: Event):
+        # Do something with event
+        print(event.id)
+
+    events.subscribe_to_all(event_handler)
+
+
+Internally this uses ``"*"`` as topic so:
+
+.. code-block:: python
+
+    from eventipy import events, Event
+
+    @events.subscribe("*")
+    def event_handler(event: Event):
+        # Do something with event
+        print(event.id)
+
+
+would also work, but is not recommended.

--- a/eventipy/__init__.py
+++ b/eventipy/__init__.py
@@ -1,4 +1,4 @@
 from eventipy.event import Event
 from eventipy.event_stream import events
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"

--- a/eventipy/event_stream.py
+++ b/eventipy/event_stream.py
@@ -10,7 +10,7 @@ from eventipy.event_handler import EventHandler
 
 logger = logging.getLogger(__name__)
 
-ALL_EVENTS = "*"
+ALL_TOPICS = "*"
 
 
 class EventStream(Sequence):
@@ -35,7 +35,7 @@ class EventStream(Sequence):
 
     async def _publish_to_subscribers(self, event: Event) -> None:
         asyncio.ensure_future(self._publish_to_topic(event.topic, event))
-        asyncio.ensure_future(self._publish_to_topic(ALL_EVENTS, event))
+        asyncio.ensure_future(self._publish_to_topic(ALL_TOPICS, event))
 
     async def _publish_to_topic(self, topic: str, event: Event):
         try:
@@ -71,7 +71,7 @@ class EventStream(Sequence):
         return wrapper
 
     def subscribe_to_all(self, event_handler: EventHandler = None):
-        return self.subscribe(topic=ALL_EVENTS, event_handler=event_handler)
+        return self.subscribe(topic=ALL_TOPICS, event_handler=event_handler)
 
     def _add_subscriber(self, topic: str, handler: Callable) -> None:
         try:

--- a/eventipy/event_stream.py
+++ b/eventipy/event_stream.py
@@ -10,6 +10,8 @@ from eventipy.event_handler import EventHandler
 
 logger = logging.getLogger(__name__)
 
+ALL_EVENTS = "*"
+
 
 class EventStream(Sequence):
     def __init__(self):
@@ -32,8 +34,12 @@ class EventStream(Sequence):
         asyncio.run(self._publish_to_subscribers(event))
 
     async def _publish_to_subscribers(self, event: Event) -> None:
+        asyncio.ensure_future(self._publish_to_topic(event.topic, event))
+        asyncio.ensure_future(self._publish_to_topic(ALL_EVENTS, event))
+
+    async def _publish_to_topic(self, topic: str, event: Event):
         try:
-            for handler in self.subscribers[event.topic]:
+            for handler in self.subscribers[topic]:
                 # Ensure handler is called, but don't wait for result
                 asyncio.ensure_future(handler(event))
         except KeyError:
@@ -63,6 +69,9 @@ class EventStream(Sequence):
             return wrapper(event_handler)
 
         return wrapper
+
+    def subscribe_to_all(self, event_handler: EventHandler = None):
+        return self.subscribe(topic=ALL_EVENTS, event_handler=event_handler)
 
     def _add_subscriber(self, topic: str, handler: Callable) -> None:
         try:

--- a/tests/unit/event_stream_test.py
+++ b/tests/unit/event_stream_test.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 import pytest
 
 from eventipy.event import Event
-from eventipy.event_stream import EventStream
+from eventipy.event_stream import EventStream, ALL_EVENTS
 
 events: EventStream
 event: Event
@@ -18,6 +18,20 @@ def run_around_tests():
     events = EventStream()
     event = Event(str(uuid4()))
     yield
+
+
+def assert_topic_handlers_were_called(topic: str):
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+
+    for index in range(len(events.subscribers[topic])):
+        handler = MagicMock()
+        handler.return_value = asyncio.Future()
+        events.subscribers[topic][index] = handler
+
+    events.publish(event)
+    for handler in events.subscribers[topic]:
+        handler.assert_called_with(event)
 
 
 def test_publish():
@@ -104,14 +118,7 @@ def test_subscribe_with_decorator_event_published():
     def handler(received_event: Event):
         return received_event.id
 
-    events.subscribers[event.topic][0] = MagicMock()
-
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-
-    events.subscribers[event.topic][0].return_value = asyncio.Future()
-    events.publish(event)
-    events.subscribers[event.topic][0].assert_called_with(event)
+    assert_topic_handlers_were_called(event.topic)
 
 
 def test_subscribe_without_decorator_event_published():
@@ -119,14 +126,23 @@ def test_subscribe_without_decorator_event_published():
         return received_event.id
 
     events.subscribe(event.topic, handler)
-    events.subscribers[event.topic][0] = MagicMock()
+    assert_topic_handlers_were_called(event.topic)
 
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
 
-    events.subscribers[event.topic][0].return_value = asyncio.Future()
-    events.publish(event)
-    events.subscribers[event.topic][0].assert_called_with(event)
+def test_subscribe_to_all_topics():
+    @events.subscribe_to_all
+    def handler(received_event: Event):
+        return received_event.id
+
+    assert_topic_handlers_were_called(ALL_EVENTS)
+
+
+def test_subscribe_to_all_without_decorator_topics():
+    def handler(received_event: Event):
+        return received_event.id
+
+    events.subscribe_to_all(event_handler=handler)
+    assert_topic_handlers_were_called(ALL_EVENTS)
 
 
 def test_add_subscriber():

--- a/tests/unit/event_stream_test.py
+++ b/tests/unit/event_stream_test.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 import pytest
 
 from eventipy.event import Event
-from eventipy.event_stream import EventStream, ALL_EVENTS
+from eventipy.event_stream import EventStream, ALL_TOPICS
 
 events: EventStream
 event: Event
@@ -134,7 +134,7 @@ def test_subscribe_to_all_topics():
     def handler(received_event: Event):
         return received_event.id
 
-    assert_topic_handlers_were_called(ALL_EVENTS)
+    assert_topic_handlers_were_called(ALL_TOPICS)
 
 
 def test_subscribe_to_all_without_decorator_topics():
@@ -142,7 +142,7 @@ def test_subscribe_to_all_without_decorator_topics():
         return received_event.id
 
     events.subscribe_to_all(event_handler=handler)
-    assert_topic_handlers_were_called(ALL_EVENTS)
+    assert_topic_handlers_were_called(ALL_TOPICS)
 
 
 def test_add_subscriber():


### PR DESCRIPTION
Add the ability to subscribe to all topics.

## Changes

- Add `subscribe_to_all` method to `EventStream`

## API Updates

### New Features *(required)*

* Add `subscribe_to_all` method to `events`/`EventStream`

### Deprecations *(required)*
none

## Checklist

- [x] Unit tests
- [x] Documentation
