### PR TITLE
Bugfix/dataclasses

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.0.0
+current_version = 2.0.1
 commit = True
 tag = False
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,7 @@ copyright = '2020, Jonatan Martens'
 author = 'Jonatan Martens'
 
 # The full version, including alpha/beta/rc tags
-release = '2.0.0'
+release = '2.0.1'
 
 # -- General configuration ---------------------------------------------------
 
@@ -57,5 +57,5 @@ html_theme = 'sphinx_rtd_theme'
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = []
 
-version = "2.0.0"
+version = "2.0.1"
 

--- a/eventipy/__init__.py
+++ b/eventipy/__init__.py
@@ -1,4 +1,4 @@
 from eventipy.event import Event
 from eventipy.event_stream import events
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"

--- a/eventipy/event.py
+++ b/eventipy/event.py
@@ -1,8 +1,10 @@
 from dataclasses import dataclass, field
-from uuid import uuid4, UUID
+from datetime import datetime
+from uuid import UUID, uuid4
 
 
 @dataclass
 class Event:
     topic: str
-    id: UUID = field(default_factory=uuid4)
+    id: UUID = field(default_factory=uuid4, init=False)
+    created_at: datetime = field(default_factory=datetime.now, init=False)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-version = "2.0.0"
+version = "2.0.1"
 
 with open("README.md", "r") as fh:
     long_description = fh.read()


### PR DESCRIPTION
Allow inheritance from `Event` while using dataclasses.

## Changes

- Initialize `id` param after initialization. This means that you cannot give your own id.
- Add field `created_at` to `Event`

## API Updates

### New Features *(required)*
none

### Deprecations *(required)*
none

## Checklist

- [ ] Unit tests
- [ ] Documentation
